### PR TITLE
Do not use relative paths with pkg_resources

### DIFF
--- a/tamkin/test/test_data.py
+++ b/tamkin/test/test_data.py
@@ -46,13 +46,14 @@ from molmod import angstrom, amu, calorie, avogadro, electronvolt, lightspeed, \
     UnitCell
 from molmod.test.common import tmpdir
 
+
 from tamkin import *
 
 
 def test_get_submolecule():
     molecule = load_molecule_charmm(
-        pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-        pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+        pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+        pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
     select = [3,4,2]
     molecule2 = molecule.get_submolecule(select)
     for i,at in enumerate(select):
@@ -73,8 +74,8 @@ def test_get_submolecule():
 
 def test_get_submolecule_cp2k():
     molecule = load_molecule_cp2k(
-        pkg_resources.resource_filename(__name__, "../data/test/cp2k/pentane/sp.out"),
-        pkg_resources.resource_filename(__name__, "../data/test/cp2k/pentane/freq.out"))
+        pkg_resources.resource_filename("tamkin", "data/test/cp2k/pentane/sp.out"),
+        pkg_resources.resource_filename("tamkin", "data/test/cp2k/pentane/freq.out"))
     select = list(range(5)) + [9,11,14]
     molecule2 = molecule.get_submolecule(select, title="this is submol", energy=5., periodic=False, symmetry_number=6)  # just trying out something
     for i,at in enumerate(select):
@@ -94,8 +95,8 @@ def test_get_submolecule_cp2k():
 
 def test_translate_pbc():
     molecule = load_molecule_cp2k(
-        pkg_resources.resource_filename(__name__, "../data/test/cp2k/pentane/sp.out"),
-        pkg_resources.resource_filename(__name__, "../data/test/cp2k/pentane/freq.out"))
+        pkg_resources.resource_filename("tamkin", "data/test/cp2k/pentane/sp.out"),
+        pkg_resources.resource_filename("tamkin", "data/test/cp2k/pentane/freq.out"))
     assert abs(molecule.unit_cell.matrix[1,1]/angstrom - 30.000) < 1e-3
     assert abs(molecule.unit_cell.matrix[0,1]/angstrom - 0.000) < 1e-3
     assert abs(molecule.coordinates[5,1]/angstrom - 13.928520) < 1e-5
@@ -127,7 +128,7 @@ def test_translate_pbc():
 
 def test_molecule_checkpoint_basic():
     mol1 = load_molecule_g03fchk(
-        pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))
+        pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))
     with tmpdir(__name__, 'test_molecule_checkpoint_basic') as dn:
         fn_out = os.path.join(dn, "molecule_checkpoint_basic.chk")
         mol1.write_to_file(fn_out)
@@ -151,7 +152,7 @@ def test_molecule_checkpoint_basic():
 
 def test_molecule_checkpoint_full():
     mol1 = load_molecule_g03fchk(
-        pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))
+        pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))
     mol1.set_default_graph()
     mol1.unit_cell = UnitCell(np.identity(3, float)*25)
     mol1.symbols = [periodic[n].symbol for n in mol1.numbers]
@@ -186,14 +187,14 @@ def test_molecule_checkpoint_full():
 
 def test_copy_with():
     mol1 = load_molecule_g03fchk(
-        pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))
+        pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))
     mol2 = mol1.copy_with(title="foo")
     assert mol2.title == "foo"
 
 
 def test_get_external_basis_new1():
     mol = load_molecule_g03fchk(
-        pkg_resources.resource_filename(__name__, "../data/test/linear/gaussian.fchk"))
+        pkg_resources.resource_filename("tamkin", "data/test/linear/gaussian.fchk"))
     eb = mol.get_external_basis_new()
     assert eb.shape[0] == 5
     # orthogonality test: the external basis should be orthogonal
@@ -211,7 +212,7 @@ def test_get_external_basis_new1():
 
 def test_get_external_basis_new2():
     mol = load_molecule_g03fchk(
-        pkg_resources.resource_filename(__name__, "../data/test/ethane/gaussian.fchk"))
+        pkg_resources.resource_filename("tamkin", "data/test/ethane/gaussian.fchk"))
     eb = mol.get_external_basis_new()
     assert eb.shape[0] == 6
     # orthogonality test: the external basis should be orthogonal
@@ -236,7 +237,7 @@ def test_rot_scan_ts():
     # The select dihedral angles do not allow an automatic assignment of the top
     # indexes.
     mol = load_molecule_g03fchk(
-        pkg_resources.resource_filename(__name__, "../data/test/sterck/paats_1h2o_b_aa.fchk"))
+        pkg_resources.resource_filename("tamkin", "data/test/sterck/paats_1h2o_b_aa.fchk"))
     diheds = [[9, 6, 7, 10], [7, 10, 18, 11], [11, 18, 10, 7]]
     for dihed in diheds:
         try:

--- a/tamkin/test/test_io.py
+++ b/tamkin/test/test_io.py
@@ -55,57 +55,57 @@ __all__ = ["IOTestCase"]
 class IOTestCase(unittest.TestCase):
     def test_load_fixed_g03com(self):
         fixed_atoms = load_fixed_g03com(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_prod.18aug.com"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_prod.18aug.com"))
         self.assertEqual(len(fixed_atoms), 48)
         self.assertEqual(fixed_atoms, list(range(114,114+48)))
 
     def test_load_molecule_g03fchk(self):
         atoms = 181
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.28aug.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.28aug.fchk"))
         self.assertEqual(molecule.hessian.shape,(atoms*3,atoms*3))
         self.assertAlmostEqual(molecule.energy, -3053.805846445570, 7)
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.28aug.fchk"),
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.28aug.fchk"),
             energy=-123.0)
         self.assertAlmostEqual(molecule.energy, -123.0, 7)
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.28aug.fchk"),
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.14mei.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.28aug.fchk"),
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.14mei.fchk"))
         self.assertAlmostEqual(molecule.energy, -18613.135744186180, 7)
 
     def test_load_molecule_g98fchk(self):
         atoms = 6
         molecule = load_molecule_g98fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/g98/freqs.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/g98/freqs.fchk"))
         self.assertEqual(molecule.hessian.shape,(atoms*3,atoms*3))
         self.assertAlmostEqual(molecule.masses[0]/amu, 12.011)
         self.assertAlmostEqual(molecule.masses[2]/amu, 1.0079)
         self.assertAlmostEqual(molecule.energy, -78.58745828877478, 7)
         molecule = load_molecule_g98fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/g98/freqs.fchk"),
+            pkg_resources.resource_filename("tamkin", "data/test/g98/freqs.fchk"),
             energy=-123.0)
         self.assertAlmostEqual(molecule.energy, -123.0, 7)
 
     def test_load_molecule_g03fchkvdw(self):
         atoms = 179
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/matvdw/R.fchk"),
-            pkg_resources.resource_filename(__name__, "../data/test/matvdw/R_SCF.fchk"),
-            pkg_resources.resource_filename(__name__, "../data/test/matvdw/R_b3lyp-d.out"))
+            pkg_resources.resource_filename("tamkin", "data/test/matvdw/R.fchk"),
+            pkg_resources.resource_filename("tamkin", "data/test/matvdw/R_SCF.fchk"),
+            pkg_resources.resource_filename("tamkin", "data/test/matvdw/R_b3lyp-d.out"))
 
         self.assertEqual(molecule.hessian.shape,(atoms*3,atoms*3))
         self.assertAlmostEqual(molecule.energy,-18612.352569964281 , 7)
 
     def test_load_fixed_fchk(self):
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/ethane/gaussian.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/ethane/gaussian.fchk"))
         assert (molecule.fixed == [0, 6, 7]).all()
 
     def test_load_molecule_cp2k(self):
         molecule = load_molecule_cp2k(
-            pkg_resources.resource_filename(__name__, "../data/test/cp2k/pentane/sp.out"),
-            pkg_resources.resource_filename(__name__, "../data/test/cp2k/pentane/freq.out"))
+            pkg_resources.resource_filename("tamkin", "data/test/cp2k/pentane/sp.out"),
+            pkg_resources.resource_filename("tamkin", "data/test/cp2k/pentane/freq.out"))
         self.assertAlmostEqual(molecule.energy, 0.012255059530862)
         self.assertEqual(molecule.multiplicity, 1)
         self.assertEqual(molecule.numbers[0], 6)
@@ -122,8 +122,8 @@ class IOTestCase(unittest.TestCase):
 
     def test_load_molecule_cp2k_23(self):
         molecule = load_molecule_cp2k(
-            pkg_resources.resource_filename(__name__, "../data/test/cp2k/john/scf.out"),
-            pkg_resources.resource_filename(__name__, "../data/test/cp2k/john/quickie.out"))
+            pkg_resources.resource_filename("tamkin", "data/test/cp2k/john/scf.out"),
+            pkg_resources.resource_filename("tamkin", "data/test/cp2k/john/quickie.out"))
         self.assertAlmostEqual(molecule.energy, -141.189006820072791)
         self.assertEqual(molecule.multiplicity, 1)
         self.assertEqual(molecule.numbers[0], 14)
@@ -140,8 +140,8 @@ class IOTestCase(unittest.TestCase):
 
     def test_load_molecule_cp2k_dan_phva(self):
         molecule = load_molecule_cp2k(
-            pkg_resources.resource_filename(__name__, "../data/test/cp2k/dan/cp2k.out"),
-            pkg_resources.resource_filename(__name__, "../data/test/cp2k/dan/freq.out"))
+            pkg_resources.resource_filename("tamkin", "data/test/cp2k/dan/cp2k.out"),
+            pkg_resources.resource_filename("tamkin", "data/test/cp2k/dan/freq.out"))
         self.assertAlmostEqual(molecule.energy, -290.409097595743333)
         self.assertEqual(molecule.multiplicity, 1)
         self.assertEqual(molecule.numbers[0], 6)
@@ -164,14 +164,14 @@ class IOTestCase(unittest.TestCase):
 
     def test_load_fixed_cp2k(self):
         fixed = load_fixed_cp2k(
-            pkg_resources.resource_filename(__name__, "../data/test/cp2k/dan/freq.out"))
+            pkg_resources.resource_filename("tamkin", "data/test/cp2k/dan/freq.out"))
         np.testing.assert_equal(fixed, np.arange(52 - 6))
 
     def test_load_molecule_cpmd(self):
         molecule = load_molecule_cpmd(
-            pkg_resources.resource_filename(__name__, "../data/test/cpmd/damp.out"),
-            pkg_resources.resource_filename(__name__, "../data/test/cpmd/GEOMETRY.xyz"),
-            pkg_resources.resource_filename(__name__, "../data/test/cpmd/MOLVIB"))
+            pkg_resources.resource_filename("tamkin", "data/test/cpmd/damp.out"),
+            pkg_resources.resource_filename("tamkin", "data/test/cpmd/GEOMETRY.xyz"),
+            pkg_resources.resource_filename("tamkin", "data/test/cpmd/MOLVIB"))
         self.assertAlmostEqual(molecule.energy, -17.14142079)
         self.assertEqual(molecule.multiplicity, 1)
         self.assertEqual(molecule.numbers[0], 8)
@@ -186,8 +186,8 @@ class IOTestCase(unittest.TestCase):
 
     def test_load_molecule_charmm(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
         self.assertAlmostEqual(molecule.energy/(1000*calorie/avogadro), -2.1303308955)
         self.assertEqual(molecule.multiplicity, 1)
         self.assertEqual(molecule.numbers[0], 6)
@@ -202,8 +202,8 @@ class IOTestCase(unittest.TestCase):
 
     def test_load_molecule_qchem(self):
         molecule = load_molecule_qchem(
-            pkg_resources.resource_filename(__name__, "../data/test/qchem/h2o2.hf.sto-3g.freq.out"),
-            hessfile=pkg_resources.resource_filename(__name__, "../data/test/qchem/hessian.dat"))
+            pkg_resources.resource_filename("tamkin", "data/test/qchem/h2o2.hf.sto-3g.freq.out"),
+            hessfile=pkg_resources.resource_filename("tamkin", "data/test/qchem/hessian.dat"))
         self.assertAlmostEqual(molecule.energy, -148.7649966058)
         self.assertEqual(molecule.multiplicity, 1)
         self.assertEqual(molecule.numbers[0], 1)
@@ -218,8 +218,8 @@ class IOTestCase(unittest.TestCase):
 
     def test_load_molecule_vasp_53(self):
         molecule = load_molecule_vasp(
-            pkg_resources.resource_filename(__name__, "../data/test/lucas/vasp_5_3_5_complex/CONTCAR_opt"),
-            pkg_resources.resource_filename(__name__, "../data/test/lucas/vasp_5_3_5_complex/OUTCAR_freq"))
+            pkg_resources.resource_filename("tamkin", "data/test/lucas/vasp_5_3_5_complex/CONTCAR_opt"),
+            pkg_resources.resource_filename("tamkin", "data/test/lucas/vasp_5_3_5_complex/OUTCAR_freq"))
         # contcar
         assert molecule.numbers[0] == 6
         assert (molecule.numbers[1:] == 1).all()
@@ -244,8 +244,8 @@ class IOTestCase(unittest.TestCase):
 
     def test_load_molecule_vasp_5_3_5_gamma(self):
         molecule = load_molecule_vasp(
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_3_5_gamma/CONTCAR_opt"),
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_3_5_gamma/OUTCAR_freq"))
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_3_5_gamma/CONTCAR_opt"),
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_3_5_gamma/OUTCAR_freq"))
         # contcar
         assert molecule.numbers[0] == 6
         assert (molecule.numbers[1:] == 1).all()
@@ -270,8 +270,8 @@ class IOTestCase(unittest.TestCase):
 
     def test_load_molecule_vasp_5_3_5_gamma_part(self):
         molecule = load_molecule_vasp(
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_3_5_gamma/CONTCAR_opt"),
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_3_5_gamma/OUTCAR_freq_part"))
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_3_5_gamma/CONTCAR_opt"),
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_3_5_gamma/OUTCAR_freq_part"))
         # outcar_freq
         hunit = electronvolt/angstrom**2
         assert molecule.hessian[0,0] == 0.0
@@ -281,8 +281,8 @@ class IOTestCase(unittest.TestCase):
 
     def test_load_molecule_vasp_5_2_11_complex(self):
         molecule = load_molecule_vasp(
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_2_11_complex/CONTCAR_opt"),
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_2_11_complex/OUTCAR_freq"))
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_2_11_complex/CONTCAR_opt"),
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_2_11_complex/OUTCAR_freq"))
         # outcar_freq
         assert molecule.masses[0] == 12.011*amu
         assert (molecule.masses[1:] == 1.000*amu).all()
@@ -298,8 +298,8 @@ class IOTestCase(unittest.TestCase):
 
     def test_load_molecule_vasp_5_2_11_complex_part(self):
         molecule = load_molecule_vasp(
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_2_11_complex/CONTCAR_opt"),
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_2_11_complex/OUTCAR_freq_part"))
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_2_11_complex/CONTCAR_opt"),
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_2_11_complex/OUTCAR_freq_part"))
         # outcar_freq
         hunit = electronvolt/angstrom**2
         assert molecule.hessian[0,0] == 0.0
@@ -310,8 +310,8 @@ class IOTestCase(unittest.TestCase):
 
     def test_load_molecule_vasp_5_3_3_complex(self):
         molecule = load_molecule_vasp(
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_3_3_complex/CONTCAR_opt"),
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_3_3_complex/OUTCAR_freq"))
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_3_3_complex/CONTCAR_opt"),
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_3_3_complex/OUTCAR_freq"))
         # outcar_freq
         assert molecule.masses[0] == 12.011*amu
         assert (molecule.masses[1:] == 1.000*amu).all()
@@ -327,8 +327,8 @@ class IOTestCase(unittest.TestCase):
 
     def test_load_molecule_vasp_5_3_3_complex_part(self):
         molecule = load_molecule_vasp(
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_3_3_complex/CONTCAR_opt"),
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_3_3_complex/OUTCAR_freq_part"))
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_3_3_complex/CONTCAR_opt"),
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_3_3_complex/OUTCAR_freq_part"))
         # outcar_freq
         hunit = electronvolt/angstrom**2
         assert molecule.hessian[0,0] == 0.0
@@ -338,22 +338,22 @@ class IOTestCase(unittest.TestCase):
 
     def test_load_molecule_vasp_5_3_5_gamma_part_energy(self):
         molecule = load_molecule_vasp(
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_3_5_gamma/CONTCAR_opt"),
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_3_5_gamma/OUTCAR_freq_part"),
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_3_5_gamma/CONTCAR_opt"),
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_3_5_gamma/OUTCAR_freq_part"),
             energy=1.476)
         assert molecule.energy == 1.476
 
     def test_load_molecule_vasp_5_3_5_gamma_part_outcar_energy(self):
         molecule = load_molecule_vasp(
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_3_5_gamma/CONTCAR_opt"),
-            pkg_resources.resource_filename(__name__, "../data/test/julianna/vasp_5_3_5_gamma/OUTCAR_freq_part"),
-            pkg_resources.resource_filename(__name__, "../data/test/lucas/vasp_5_3_5_complex/OUTCAR_freq"))
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_3_5_gamma/CONTCAR_opt"),
+            pkg_resources.resource_filename("tamkin", "data/test/julianna/vasp_5_3_5_gamma/OUTCAR_freq_part"),
+            pkg_resources.resource_filename("tamkin", "data/test/lucas/vasp_5_3_5_complex/OUTCAR_freq"))
         assert molecule.energy == -24.11901936*electronvolt
 
     def test_checkpoint(self):
         molecule = load_molecule_cp2k(
-            pkg_resources.resource_filename(__name__, "../data/test/cp2k/pentane/sp.out"),
-            pkg_resources.resource_filename(__name__, "../data/test/cp2k/pentane/freq.out"))
+            pkg_resources.resource_filename("tamkin", "data/test/cp2k/pentane/sp.out"),
+            pkg_resources.resource_filename("tamkin", "data/test/cp2k/pentane/freq.out"))
         nma1 = NMA(molecule)
         with tmpdir(__name__, 'test_checkpoint') as dn:
             fn_out = os.path.join(dn, 'test.chk')
@@ -367,12 +367,12 @@ class IOTestCase(unittest.TestCase):
         self.assertEqual(nma1.coordinates.shape, nma2.coordinates.shape)
         self.assertEqual(nma1.inertia_tensor.shape, nma2.inertia_tensor.shape)
 
-        self.assert_(abs(nma1.freqs - nma2.freqs).max()/abs(nma1.freqs).max() < 1e-15)
-        self.assert_(abs(nma1.modes - nma2.modes).max()/abs(nma1.modes).max() < 1e-15)
-        self.assert_(abs(nma1.masses - nma2.masses).max()/abs(nma1.masses).max() < 1e-15)
-        self.assert_(abs(nma1.coordinates - nma2.coordinates).max()/abs(nma1.coordinates).max() < 1e-15)
-        self.assert_(abs(nma1.inertia_tensor - nma2.inertia_tensor).max()/abs(nma1.inertia_tensor).max() < 1e-15)
-        self.assert_((nma1.numbers==nma2.numbers).all())
+        assert abs(nma1.freqs - nma2.freqs).max()/abs(nma1.freqs).max() < 1e-15
+        assert abs(nma1.modes - nma2.modes).max()/abs(nma1.modes).max() < 1e-15
+        assert abs(nma1.masses - nma2.masses).max()/abs(nma1.masses).max() < 1e-15
+        assert abs(nma1.coordinates - nma2.coordinates).max()/abs(nma1.coordinates).max() < 1e-15
+        assert abs(nma1.inertia_tensor - nma2.inertia_tensor).max()/abs(nma1.inertia_tensor).max() < 1e-15
+        assert (nma1.numbers==nma2.numbers).all()
 
         self.assertAlmostEqual(nma1.mass, nma2.mass)
         self.assertAlmostEqual(nma1.energy, nma2.energy)
@@ -380,27 +380,27 @@ class IOTestCase(unittest.TestCase):
         self.assertEqual(nma1.symmetry_number, nma2.symmetry_number)
 
     def test_load_indices(self):
-        blocks = load_indices(pkg_resources.resource_filename(__name__, "../data/test/an/fixed.07.txt"), groups=True)
+        blocks = load_indices(pkg_resources.resource_filename("tamkin", "data/test/an/fixed.07.txt"), groups=True)
         self.assertEqual(blocks, [[3,2,6]])
-        blocks = load_indices(pkg_resources.resource_filename(__name__, "../data/test/an/fixed.07.txt"))
+        blocks = load_indices(pkg_resources.resource_filename("tamkin", "data/test/an/fixed.07.txt"))
         self.assertEqual(blocks, [3,2,6])
-        blocks = load_indices(pkg_resources.resource_filename(__name__, "../data/test/an/fixed.08.txt"))
+        blocks = load_indices(pkg_resources.resource_filename("tamkin", "data/test/an/fixed.08.txt"))
         self.assertEqual(blocks, [5,4,8])
 
     def test_load_indices_ranges(self):
-        blocks = load_indices(pkg_resources.resource_filename(__name__, "../data/test/an/fixed_ranges.txt"), groups=True)
+        blocks = load_indices(pkg_resources.resource_filename("tamkin", "data/test/an/fixed_ranges.txt"), groups=True)
         self.assertEqual(blocks, [[0, 2, 3, 4], [9, 10, 11, 12, 13, 19], [21]])
-        blocks = load_indices(pkg_resources.resource_filename(__name__, "../data/test/an/fixed_ranges.txt"), shift=0)
+        blocks = load_indices(pkg_resources.resource_filename("tamkin", "data/test/an/fixed_ranges.txt"), shift=0)
         self.assertEqual(blocks, [1, 3, 4, 5, 10, 11, 12, 13, 14, 20, 22])
-        blocks = load_indices(pkg_resources.resource_filename(__name__, "../data/test/an/fixed_ranges_shift.txt"), groups=True)
+        blocks = load_indices(pkg_resources.resource_filename("tamkin", "data/test/an/fixed_ranges_shift.txt"), groups=True)
         self.assertEqual(blocks, [[1, 3, 4, 5], [10, 11, 12, 13, 14, 20], [22]])
-        blocks = load_indices(pkg_resources.resource_filename(__name__, "../data/test/an/fixed_ranges_shift.txt"), shift=0)
+        blocks = load_indices(pkg_resources.resource_filename("tamkin", "data/test/an/fixed_ranges_shift.txt"), shift=0)
         self.assertEqual(blocks, [1, 3, 4, 5, 10, 11, 12, 13, 14, 20, 22])
 
     def test_dump_modes_xyz(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
         nma = NMA(molecule)
         with tmpdir(__name__, 'test_dump_modes_xyz') as dn:
             prefix = os.path.join(dn, 'mode')
@@ -424,8 +424,8 @@ class IOTestCase(unittest.TestCase):
 
     def test_dump_modes_gaussian(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
         nma = NMA(molecule)
         with tmpdir(__name__, 'test_dump_modes_gaussian') as dn:
             # blind test, no double checking of the output file
@@ -511,17 +511,17 @@ class IOTestCase(unittest.TestCase):
 
     def test_punch(self):
         mol0 = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/punch/gaussian.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/punch/gaussian.fchk"))
         mol1 = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/punch/gaussian.fchk"),
-            fn_punch=pkg_resources.resource_filename(__name__, "../data/test/punch/fort.7"))
+            pkg_resources.resource_filename("tamkin", "data/test/punch/gaussian.fchk"),
+            fn_punch=pkg_resources.resource_filename("tamkin", "data/test/punch/fort.7"))
         assert abs(mol0.gradient - mol1.gradient).max() < 1e-8
         assert abs(mol0.hessian - mol1.hessian).max() < 1e-8
 
     def test_dftd3(self):
         assert load_dftd3(
-            pkg_resources.resource_filename(__name__, "../data/test/dftd3/dftd3.out")) == -0.00330057
+            pkg_resources.resource_filename("tamkin", "data/test/dftd3/dftd3.out")) == -0.00330057
 
     def test_dftd_orca(self):
         assert load_dftd_orca(
-            pkg_resources.resource_filename(__name__, "../data/test/matvdw/R_b3lyp-d.out")) == -0.404083275
+            pkg_resources.resource_filename("tamkin", "data/test/matvdw/R_b3lyp-d.out")) == -0.404083275

--- a/tamkin/test/test_nma.py
+++ b/tamkin/test/test_nma.py
@@ -57,7 +57,7 @@ class NMATestCase(unittest.TestCase):
             return
         unit_matrix = np.dot(modes.transpose(), modes)
         error_max = abs(unit_matrix - np.identity(len(unit_matrix))).max()
-        self.assert_(error_max < 1e-5)
+        assert error_max < 1e-5
 
     def check_freqs(self, expected_freqs, nma, precision=3, check_zeros=False):
         """Check the frequencies in the partition function against expected values
@@ -95,10 +95,10 @@ class NMATestCase(unittest.TestCase):
 
     def test_phva_react_mat(self):
         fixed_atoms = load_fixed_g03com(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.14mei.com"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.14mei.com"))
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.28aug.fchk"),
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.14mei.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.28aug.fchk"),
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.14mei.fchk"))
         nma = NMA(molecule, PHVA(fixed_atoms))
         self.check_ortho(nma.modes)
 
@@ -219,10 +219,10 @@ class NMATestCase(unittest.TestCase):
 
     def test_phva_trans_mat(self):
         fixed_atoms = load_fixed_g03com(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_TS.28aug.com"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_TS.28aug.com"))
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_TS.28aug.fchk"),
-            pkg_resources.resource_filename(__name__, "../data/test/mat/5Tp_p_TS.oniom21apr_HF.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_TS.28aug.fchk"),
+            pkg_resources.resource_filename("tamkin", "data/test/mat/5Tp_p_TS.oniom21apr_HF.fchk"))
         nma = NMA(molecule, PHVA(fixed_atoms))
         self.check_ortho(nma.modes)
 
@@ -302,7 +302,7 @@ class NMATestCase(unittest.TestCase):
         for treatment, precision_wn, shift in (Full(), 0, 6), (ConstrainExt(), 3, 0):
             ## aa.fchk
             molecule = load_molecule_g03fchk(
-                pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))
+                pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))
             nma = NMA(molecule, treatment)
             self.check_ortho(nma.modes)
 
@@ -325,7 +325,7 @@ class NMATestCase(unittest.TestCase):
 
             ## aarad.fchk
             molecule = load_molecule_g03fchk(
-                pkg_resources.resource_filename(__name__, "../data/test/sterck/aarad.fchk"))
+                pkg_resources.resource_filename("tamkin", "data/test/sterck/aarad.fchk"))
             nma = NMA(molecule, treatment)
 
             # expected frequencies from aa.log
@@ -350,7 +350,7 @@ class NMATestCase(unittest.TestCase):
     def test_teller_redlich_gas_react_sterck(self):
         for treatment, precision_wn, shift in (Full(), 0, 6), (ConstrainExt(), 3, 0):
             mol1 = load_molecule_g03fchk(
-                pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))
+                pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))
             nma1 = NMA(mol1, treatment)
             self.check_ortho(nma1.modes)
 
@@ -378,7 +378,7 @@ class NMATestCase(unittest.TestCase):
         for treatment, precision_wn, shift in (Full(), 0, 6), (ConstrainExt(), 3, 0):
             ## paats.fchk
             molecule = load_molecule_g03fchk(
-                pkg_resources.resource_filename(__name__, "../data/test/sterck/paats.fchk"))
+                pkg_resources.resource_filename("tamkin", "data/test/sterck/paats.fchk"))
             nma = NMA(molecule, treatment)
             self.check_ortho(nma.modes)
 
@@ -438,12 +438,12 @@ class NMATestCase(unittest.TestCase):
                 [ 0.03964,  0.99904, 0.01875],
                 [-0.01956, -0.01799, 0.99965],
             ])
-            self.assert_(abs(evecs-expected_evecs).max() < 1e-3)
+            assert abs(evecs-expected_evecs).max() < 1e-3
 
     def test_gas_pentane(self):
         molecule = load_molecule_cp2k(
-            pkg_resources.resource_filename(__name__, "../data/test/cp2k/pentane/sp.out"),
-            pkg_resources.resource_filename(__name__, "../data/test/cp2k/pentane/freq.out"),
+            pkg_resources.resource_filename("tamkin", "data/test/cp2k/pentane/sp.out"),
+            pkg_resources.resource_filename("tamkin", "data/test/cp2k/pentane/freq.out"),
             is_periodic=False)
         nma = NMA(molecule, ConstrainExt(), do_modes=False)
 
@@ -462,9 +462,9 @@ class NMATestCase(unittest.TestCase):
 
     def test_gas_water_cpmd(self):
         molecule = load_molecule_cpmd(
-            pkg_resources.resource_filename(__name__, "../data/test/cpmd/damp.out"),
-            pkg_resources.resource_filename(__name__, "../data/test/cpmd/GEOMETRY.xyz"),
-            pkg_resources.resource_filename(__name__, "../data/test/cpmd/MOLVIB"),
+            pkg_resources.resource_filename("tamkin", "data/test/cpmd/damp.out"),
+            pkg_resources.resource_filename("tamkin", "data/test/cpmd/GEOMETRY.xyz"),
+            pkg_resources.resource_filename("tamkin", "data/test/cpmd/MOLVIB"),
             is_periodic=True)
         nma = NMA(molecule, Full(), do_modes=False)
         expected_freqs = np.array([
@@ -482,34 +482,34 @@ class NMATestCase(unittest.TestCase):
 
     def test_vsa(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
 
         #  --- single atom as subsystem: results should be three translations
         subs = load_indices(
-            pkg_resources.resource_filename(__name__, "../data/test/an/fixed.01.txt"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/fixed.01.txt"))
         nma = NMA(molecule, VSA(subs))
         self.check_ortho(nma.modes)
-        self.assert_(len(nma.zeros)==3)
+        assert len(nma.zeros)==3
         expected_freqs = np.array([-0.23313896,  0.01475299,  0.06910995])
         self.check_freqs(expected_freqs, nma, 0, check_zeros=True)
 
         #  ---  atoms of subsystem are collinear: not yet external_basis implemented...
         subs = load_indices(
-            pkg_resources.resource_filename(__name__, "../data/test/an/fixed.02.txt"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/fixed.02.txt"))
         nma = NMA(molecule, VSA(subs))
         self.check_ortho(nma.modes)
-        self.assert_(len(nma.zeros)==5)
+        assert len(nma.zeros)==5
         expected_freqs = np.array([ -3.30245504e-01,-2.51869284e-01, -1.16805787e-01,
                1.37273058e-01,1.82394281e-01,1.05116208e+03])
         self.check_freqs(expected_freqs, nma, 0, check_zeros=True)
 
         #  --- atoms of subsystem are not collinear
         subs = load_indices(
-            pkg_resources.resource_filename(__name__, "../data/test/an/fixed.03.txt"))  # atom 1 to atom 7
+            pkg_resources.resource_filename("tamkin", "data/test/an/fixed.03.txt"))  # atom 1 to atom 7
         nma = NMA(molecule, VSA(subs))
         self.check_ortho(nma.modes)
-        self.assert_(len(nma.zeros)==6)
+        assert len(nma.zeros)==6
         expected_freqs = np.array([ # taken from previous working python version
                -0.00962070029417,-0.00653077581838,-0.000469690606812,-0.000148860724889,
                0.000379327735493, 0.0142496837765,   # These are the zeros.
@@ -520,31 +520,31 @@ class NMATestCase(unittest.TestCase):
     def test_vsa_no_mass(self):
         # Modes are a priori known to be non-orthogonal, so no 'self.check_ortho(nma.modes)'
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
 
         #  --- single atom as subsystem: results should be three translations
         subs = load_indices(
-            pkg_resources.resource_filename(__name__, "../data/test/an/fixed.01.txt"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/fixed.01.txt"))
         nma = NMA(molecule, VSANoMass(subs))
-        self.assert_(len(nma.zeros)==3)
+        assert len(nma.zeros)==3
         expected_freqs = np.array([-0.4205594, 0.03940166, 0.13774798])
         self.check_freqs(expected_freqs, nma, 0, check_zeros=True)
 
         #  ---  atoms of subsystem are collinear
         subs = load_indices(
-            pkg_resources.resource_filename(__name__, "../data/test/an/fixed.02.txt"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/fixed.02.txt"))
         nma = NMA(molecule, VSANoMass(subs))
-        self.assert_(len(nma.zeros)==5)
+        assert len(nma.zeros)==5
         expected_freqs = np.array([-6.07975753e-01,-3.47371852e-01,6.34080688e-02,
                 1.05589989e-01,1.68657446e-01,1.21704836e+03])
         self.check_freqs(expected_freqs, nma, -1, check_zeros=True)
 
         #  --- atoms of subsystem are not collinear
         subs = load_indices(
-            pkg_resources.resource_filename(__name__, "../data/test/an/fixed.03.txt"))  # atom 1 to atom 7
+            pkg_resources.resource_filename("tamkin", "data/test/an/fixed.03.txt"))  # atom 1 to atom 7
         nma = NMA(molecule, VSANoMass(subs))
-        self.assert_(len(nma.zeros)==6)
+        assert len(nma.zeros)==6
         expected_freqs = np.array([ # taken from previous working python version
                         -0.0299898080453, -0.0124485604422, -0.000583010131998, -0.000190084696013,
                         0.000469660947606, 0.0233987667917,    # These are the zeros.
@@ -554,10 +554,10 @@ class NMATestCase(unittest.TestCase):
 
     def test_mbh(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
         blocks = load_indices(
-            pkg_resources.resource_filename(__name__, "../data/test/an/fixed.07.txt"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/fixed.07.txt"),
             groups=True)
         nma = NMA(molecule, MBH(blocks))
         self.check_ortho(nma.modes)
@@ -567,7 +567,7 @@ class NMATestCase(unittest.TestCase):
 
     def test_mbh_ethane(self):
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/ethane/gaussian.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/ethane/gaussian.fchk"))
         blocks = [[1, 0, 2, 6, 7], [1, 0, 3, 4, 5 ]]
         nma = NMA(molecule, MBH(blocks))
         self.assertEqual(len(nma.freqs), 7)
@@ -577,7 +577,7 @@ class NMATestCase(unittest.TestCase):
     def test_mbhconstrainext(self):
         # load the plain Hessian
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))
         blocks = [[3,2,6],[6,7,8]]
         nma1 = NMA(molecule)
         nma2 = NMA(molecule, ConstrainExt(gradient_threshold=1e-2))
@@ -602,8 +602,8 @@ class NMATestCase(unittest.TestCase):
     def test_mbh_raise_ext(self):
         # load the plain Hessian
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
         blocks = [[3,2,6],[6,7,8]]
         nma1 = NMA(molecule)
         nma2 = NMA(molecule, MBH(blocks))
@@ -635,13 +635,13 @@ class NMATestCase(unittest.TestCase):
 
     def test_phva_mbh(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
         blocks = load_indices(
-            pkg_resources.resource_filename(__name__, "../data/test/an/fixed.07.txt"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/fixed.07.txt"),
             groups=True)
         fixed = load_indices(
-            pkg_resources.resource_filename(__name__, "../data/test/an/fixed.06.txt"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/fixed.06.txt"))
         nma = NMA(molecule, PHVA_MBH(fixed,blocks))
         expected_freqs = np.array([214.28936269,   596.97481532,   663.5290044,    787.84964637,
                  859.68400023, 1096.26899018,  1160.4094257, 1224.87768013,  1310.51036299,
@@ -654,8 +654,8 @@ class NMATestCase(unittest.TestCase):
 
     def test_constrain1(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
         fixed = [[1,2]]
         nma = NMA(molecule, Constrain(fixed))
         #print nma.freqs/lightspeed*centimeter
@@ -667,8 +667,8 @@ class NMATestCase(unittest.TestCase):
 
     def test_constrain2(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
         fixed = [[1,2], [0,4], [0,5],[2,8],[3,4],[4,5],[5,6],[6,7],[7,8],[7,1],[7,3]]
         nma = NMA(molecule, Constrain(fixed))
         #print nma.freqs/lightspeed*centimeter
@@ -680,11 +680,11 @@ class NMATestCase(unittest.TestCase):
 
     def test_sandra(self):
         cases = [
-            (pkg_resources.resource_filename(__name__, "../data/test/sandra/F_freq.fchk"),
+            (pkg_resources.resource_filename("tamkin", "data/test/sandra/F_freq.fchk"),
              []),
-            (pkg_resources.resource_filename(__name__, "../data/test/sandra/HF_freq.fchk"),
+            (pkg_resources.resource_filename("tamkin", "data/test/sandra/HF_freq.fchk"),
              [4472.7168]),
-            (pkg_resources.resource_filename(__name__, "../data/test/sandra/ts_FHF_optfreq.fchk"),
+            (pkg_resources.resource_filename("tamkin", "data/test/sandra/ts_FHF_optfreq.fchk"),
              [-4.1374, 2.0214, 13.3582, 106.6359]),
         ]
         for fn_fchk, expected_freqs in cases:

--- a/tamkin/test/test_nmatools.py
+++ b/tamkin/test/test_nmatools.py
@@ -54,10 +54,10 @@ class NMAToolsTestCase(unittest.TestCase):
 
     def test_load_coordinates_charmm(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
         coordinates, masses, symbols = load_coordinates_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"))
         for at in range(9):
             self.assertAlmostEqual(molecule.masses[at], masses[at], 3)
             for j in range(3):
@@ -65,13 +65,13 @@ class NMAToolsTestCase(unittest.TestCase):
 
     def test_load_modes_charmm(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
 
         # full Hessian
         nma = NMA(molecule)
         modes2, freqs2, masses2 = load_modes_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.modes.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.modes.full"))
         for index in range(6,27):
             for j in range(27):
                 self.assertAlmostEqual(abs(nma.modes[j,index]), abs(modes2[j,index]), 7)
@@ -81,7 +81,7 @@ class NMAToolsTestCase(unittest.TestCase):
         # MBH
         nma = NMA(molecule, MBH([[5,6,7,8]]))
         modes2, freqs2, masses2 = load_modes_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.modes.mbh"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.modes.mbh"))
         for index in range(6,21):
             for j in range(27):
                 self.assertAlmostEqual(abs(nma.modes[j,index]), abs(modes2[j,index]), 7)
@@ -90,11 +90,11 @@ class NMAToolsTestCase(unittest.TestCase):
 
     def test_overlap(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
         nma1 = NMA(molecule)
         fixed = load_indices(
-            pkg_resources.resource_filename(__name__, "../data/test/an/fixed.06.txt"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/fixed.06.txt"))
         nma2 = NMA(molecule, PHVA(fixed))
         overlap = compute_overlap(nma1, nma2)
         overlap = compute_overlap((nma1.modes, nma1.freqs), (nma2.modes, nma2.freqs))
@@ -106,9 +106,9 @@ class NMAToolsTestCase(unittest.TestCase):
     def test_delta_vector(self):
         # from charmmcor
         coor1,masses1,symb1 = load_coordinates_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"))
         coor2,masses2,symb2 = load_coordinates_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.2.cor"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.2.cor"))
         delta = compute_delta(coor1, coor2)
         # TODO
         #self.assertAlmostEqual()
@@ -117,8 +117,8 @@ class NMAToolsTestCase(unittest.TestCase):
 
     def test_eigenvalue_sensitivity(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
         nma = NMA(molecule)
         for i in range(7, 27):
             sensit = compute_sensitivity_freq(nma, i)
@@ -126,40 +126,40 @@ class NMAToolsTestCase(unittest.TestCase):
 
     def test_create_blocks_peptide_charmm(self):
         blocks1 = create_blocks_peptide_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/charmm/crambin.crd"),
+            pkg_resources.resource_filename("tamkin", "data/test/charmm/crambin.crd"),
             "RTB", blocksize=1)
         blocks2 = create_blocks_peptide_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/charmm/crambin.crd"),
+            pkg_resources.resource_filename("tamkin", "data/test/charmm/crambin.crd"),
             "RTB", blocksize=2)
         self.assertEqual(len(blocks1) // 2 + 1, len(blocks2))
         subs1 = create_subs_peptide_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/charmm/crambin.crd"),
+            pkg_resources.resource_filename("tamkin", "data/test/charmm/crambin.crd"),
             frequency=1)
         subs2 = create_subs_peptide_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/charmm/crambin.crd"),
+            pkg_resources.resource_filename("tamkin", "data/test/charmm/crambin.crd"),
             frequency=2)
         self.assertEqual(len(subs1) // 2, len(subs2))
 
         blocks = create_blocks_peptide_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/charmm/crambin.crd"))
+            pkg_resources.resource_filename("tamkin", "data/test/charmm/crambin.crd"))
         self.assertEqual(len(blocks), 91)
         blocks = create_blocks_peptide_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/charmm/crambin.crd"),
+            pkg_resources.resource_filename("tamkin", "data/test/charmm/crambin.crd"),
             "dihedral")
         self.assertEqual(len(blocks), 91)
         blocks = create_blocks_peptide_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/charmm/crambin.crd"),
+            pkg_resources.resource_filename("tamkin", "data/test/charmm/crambin.crd"),
             "RHbending")
         self.assertEqual(len(blocks),136)
         blocks = create_blocks_peptide_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/charmm/crambin.crd"),
+            pkg_resources.resource_filename("tamkin", "data/test/charmm/crambin.crd"),
             "normal")
         self.assertEqual(len(blocks), 91)
 
     def test_plot_spectrum(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
         nma = NMA(molecule)
         invcm = lightspeed/centimeter
         with tmpdir(__name__, 'test_plot_spectrum') as dn:
@@ -191,8 +191,8 @@ class NMAToolsTestCase(unittest.TestCase):
 
     def test_create_enm_molecule(self):
         molecule = load_molecule_charmm(
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.cor"),
-            pkg_resources.resource_filename(__name__, "../data/test/an/ethanol.hess.full"))
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.cor"),
+            pkg_resources.resource_filename("tamkin", "data/test/an/ethanol.hess.full"))
         selected = range(5)
         mol = create_enm_molecule(molecule, selected)
         nma = NMA(mol)

--- a/tamkin/test/test_partf.py
+++ b/tamkin/test/test_partf.py
@@ -54,10 +54,10 @@ __all__ = ["PartFunTestCase"]
 class PartFunTestCase(unittest.TestCase):
     def test_phva_react_mat(self):
         fixed_atoms = load_fixed_g03com(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.14mei.com"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.14mei.com"))
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.28aug.fchk"),
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.14mei.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.28aug.fchk"),
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.14mei.fchk"))
         nma = NMA(molecule, PHVA(fixed_atoms))
         pf = PartFun(nma)
 
@@ -68,13 +68,13 @@ class PartFunTestCase(unittest.TestCase):
 
     def test_phva_rate_const_mat(self):
         fixed_atoms = load_fixed_g03com(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.14mei.com"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.14mei.com"))
         mol_react = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.28aug.fchk"),
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.14mei.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.28aug.fchk"),
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.14mei.fchk"))
         mol_trans = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_TS.28aug.fchk"),
-            pkg_resources.resource_filename(__name__, "../data/test/mat/5Tp_p_TS.oniom21apr_HF.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_TS.28aug.fchk"),
+            pkg_resources.resource_filename("tamkin", "data/test/mat/5Tp_p_TS.oniom21apr_HF.fchk"))
         pf_react = PartFun(NMA(mol_react, PHVA(fixed_atoms)))
         pf_trans = PartFun(NMA(mol_trans, PHVA(fixed_atoms)))
         km = KineticModel([pf_react], pf_trans)
@@ -97,7 +97,7 @@ class PartFunTestCase(unittest.TestCase):
         for treatment, precision_wn, shift in (Full(), 0, 6), (ConstrainExt(), 3, 0):
             ## aa.fchk
             molecule = load_molecule_g03fchk(
-                pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))
+                pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))
             nma = NMA(molecule, treatment)
             pf = PartFun(nma, [ExtTrans(), ExtRot(1)])
             temp = 298.150
@@ -134,7 +134,7 @@ class PartFunTestCase(unittest.TestCase):
 
             ## aarad.fchk
             molecule = load_molecule_g03fchk(
-                pkg_resources.resource_filename(__name__, "../data/test/sterck/aarad.fchk"))
+                pkg_resources.resource_filename("tamkin", "data/test/sterck/aarad.fchk"))
             nma = NMA(molecule, treatment)
             pf = PartFun(nma, [ExtTrans(), ExtRot(1)])
 
@@ -156,7 +156,7 @@ class PartFunTestCase(unittest.TestCase):
         for treatment, precision_wn, shift in (Full(), 0, 6), (ConstrainExt(), 3, 0):
             ## paats.fchk
             molecule = load_molecule_g03fchk(
-                pkg_resources.resource_filename(__name__, "../data/test/sterck/paats.fchk"))
+                pkg_resources.resource_filename("tamkin", "data/test/sterck/paats.fchk"))
             nma = NMA(molecule, treatment)
             pf = PartFun(nma, [ExtTrans(), ExtRot(1)])
             temp = 298.150
@@ -178,11 +178,11 @@ class PartFunTestCase(unittest.TestCase):
 
     def test_gas_rate_const_sterck(self):
         mol_react1 = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))
         mol_react2 = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/aarad.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/aarad.fchk"))
         mol_trans = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/paats.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/paats.fchk"))
         pf_react1 = PartFun(NMA(mol_react1, ConstrainExt()), [ExtTrans(cp=False), ExtRot(1)])
         pf_react2 = PartFun(NMA(mol_react2, ConstrainExt()), [ExtTrans(cp=False), ExtRot(1)])
         pf_trans = PartFun(NMA(mol_trans, ConstrainExt()), [ExtTrans(cp=False), ExtRot(1)])
@@ -204,10 +204,10 @@ class PartFunTestCase(unittest.TestCase):
 
     def test_derivatives(self):
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/ethane/gaussian.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/ethane/gaussian.fchk"))
         nma = NMA(molecule)
         rotscan = load_rotscan_g03log(
-            pkg_resources.resource_filename(__name__, "../data/test/rotor/gaussian.log"))
+            pkg_resources.resource_filename("tamkin", "data/test/rotor/gaussian.log"))
         rotor = Rotor(rotscan, molecule, rotsym=3, even=True)
         for classical in True, False:
             for cp in True, False:
@@ -252,7 +252,7 @@ class PartFunTestCase(unittest.TestCase):
 
     def test_chemical_potential_cp(self):
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/ethane/gaussian.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/ethane/gaussian.fchk"))
         nma = NMA(molecule)
         pf = PartFun(nma, [ExtTrans(cp=True), ExtRot()])
         N0 = 1.0
@@ -271,7 +271,7 @@ class PartFunTestCase(unittest.TestCase):
             pf.pressure = 0.5*(p0+p1)
             mu = pf.chemical_potential(temp)
             error = abs(F1 - F0 - (N1-N0)*mu)
-            self.assert_(error < 1e-12)
+            assert error < 1e-12
             # check the helper function and the definition of the chemical
             # potential in an ideal gas
             self.assertAlmostEqual(pf.translational.helpern(temp, 0) - pf.translational.helper(temp, 0), 0.0)
@@ -283,7 +283,7 @@ class PartFunTestCase(unittest.TestCase):
 
     def test_chemical_potential_cv(self):
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/ethane/gaussian.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/ethane/gaussian.fchk"))
         nma = NMA(molecule)
         pf = PartFun(nma, [ExtTrans(cp=False), ExtRot()])
         N0 = 1.0
@@ -301,7 +301,7 @@ class PartFunTestCase(unittest.TestCase):
             F1 = pf.free_energy(temp)*N1
             mu = pf.chemical_potential(temp)
             error = abs(F1 - F0 - (N1-N0)*mu)
-            self.assert_(error < 1e-8)
+            assert error < 1e-8
             # check the helper function and the definition of the chemical
             # potential in an ideal gas
             self.assertAlmostEqual(pf.translational.helpern(temp, 0) - pf.translational.helper(temp, 0), -1)
@@ -314,7 +314,7 @@ class PartFunTestCase(unittest.TestCase):
     def test_logn(self):
         for cp in False, True:
             molecule = load_molecule_g03fchk(
-                pkg_resources.resource_filename(__name__, "../data/test/ethane/gaussian.fchk"))
+                pkg_resources.resource_filename("tamkin", "data/test/ethane/gaussian.fchk"))
             nma = NMA(molecule)
             pf = PartFun(nma, [ExtTrans(cp=cp), ExtRot()])
             temps = np.array([300.0,400.0,500.0,600.0,700.0])
@@ -328,7 +328,7 @@ class PartFunTestCase(unittest.TestCase):
     def test_logv(self):
         for cp in False, True:
             molecule = load_molecule_g03fchk(
-                pkg_resources.resource_filename(__name__, "../data/test/ethane/gaussian.fchk"))
+                pkg_resources.resource_filename("tamkin", "data/test/ethane/gaussian.fchk"))
             nma = NMA(molecule)
             pf = PartFun(nma, [ExtTrans(cp=cp), ExtRot()])
             temps = np.array([300.0,400.0,500.0,600.0,700.0])
@@ -341,7 +341,7 @@ class PartFunTestCase(unittest.TestCase):
     def test_derived_quantities(self):
         # internal energy, heat capacity and entropy
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))
         nma = NMA(molecule, ConstrainExt())
         pf = PartFun(nma, [ExtTrans(cp=True), ExtRot(1)])
 
@@ -387,7 +387,7 @@ class PartFunTestCase(unittest.TestCase):
     def test_classical1(self):
         pf = PartFun(
             NMA(load_molecule_g03fchk(
-                pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))),
+                pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))),
             [Vibrations(classical=True), ExtTrans(), ExtRot(1)],
         )
 
@@ -399,12 +399,12 @@ class PartFunTestCase(unittest.TestCase):
     def test_classical2(self):
         pfc = PartFun(
             NMA(load_molecule_g03fchk(
-                pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))),
+                pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))),
             [Vibrations(True), ExtTrans(), ExtRot(1)],
         )
         pfq = PartFun(
             NMA(load_molecule_g03fchk(
-                pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))),
+                pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))),
             [Vibrations(False), ExtTrans(), ExtRot(1)],
         )
 
@@ -431,7 +431,7 @@ class PartFunTestCase(unittest.TestCase):
 
         # values taken from aa.log
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))
         pf = PartFun(NMA(molecule, ConstrainExt()), [ExtTrans(cp=True)])
         # translational
         # WARNING: internal_heat returns enthalpy, turn it into internal energy
@@ -442,7 +442,7 @@ class PartFunTestCase(unittest.TestCase):
         self.assertAlmostEqual(pf.translational.entropy(temp)/(calmolK), 38.699, 2)
 
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))
         pf = PartFun(NMA(molecule, ConstrainExt()), [ExtRot(1)])
         # rotational
         self.assertAlmostEqual(pf.rotational.internal_heat(temp)/(kcalmol), 0.889, 2)
@@ -451,7 +451,7 @@ class PartFunTestCase(unittest.TestCase):
 
     def test_linear(self):
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/linear/gaussian.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/linear/gaussian.fchk"))
         pf = PartFun(NMA(molecule, ConstrainExt()), [ExtTrans(),ExtRot(2)])
 
         # check the inertia moments (eigenvalues only)
@@ -478,13 +478,13 @@ class PartFunTestCase(unittest.TestCase):
 
     def test_equilibrium(self):
         mol_react1 = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/aa_1h2o_a.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/aa_1h2o_a.fchk"))
         mol_react2 = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/aarad.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/aarad.fchk"))
         mol_complex = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/paaprc_1h2o_b_aa.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/paaprc_1h2o_b_aa.fchk"))
         mol_trans = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/paats_1h2o_b_aa.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/paats_1h2o_b_aa.fchk"))
         pf_react1 = PartFun(NMA(mol_react1), [ExtTrans(), ExtRot(1)])
         pf_react2 = PartFun(NMA(mol_react2), [ExtTrans(), ExtRot(1)])
         pf_complex = PartFun(NMA(mol_complex), [ExtTrans(), ExtRot(1)])
@@ -537,7 +537,7 @@ class PartFunTestCase(unittest.TestCase):
 
     def test_pcm_correction(self):
         mol = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/aa_1h2o_a.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/aa_1h2o_a.fchk"))
         pf0 = PartFun(NMA(mol), [])
         pf1 = PartFun(NMA(mol), [PCMCorrection((-5*kjmol,300))])
         pf2 = PartFun(NMA(mol), [PCMCorrection((-5*kjmol,300), (-10*kjmol,600))])
@@ -554,10 +554,10 @@ class PartFunTestCase(unittest.TestCase):
 
     def test_zero_point_energy(self):
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/ethane/gaussian.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/ethane/gaussian.fchk"))
         nma = NMA(molecule)
         rotscan = load_rotscan_g03log(
-            pkg_resources.resource_filename(__name__, "../data/test/rotor/gaussian.log"))
+            pkg_resources.resource_filename("tamkin", "data/test/rotor/gaussian.log"))
         rotor = Rotor(rotscan, molecule, rotsym=3, even=True)
         pf = PartFun(nma, [ExtTrans(), ExtRot(), rotor, Vibrations()])
         # check the vibrational part
@@ -579,7 +579,7 @@ class PartFunTestCase(unittest.TestCase):
 
     def test_freq_threshold(self):
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/ethane/gaussian.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/ethane/gaussian.fchk"))
         nma = NMA(molecule)
         pf = PartFun(nma, [ExtTrans(), ExtRot(), Vibrations()])
         assert len(pf.vibrational.zero_freqs) == 6

--- a/tamkin/test/test_pftools.py
+++ b/tamkin/test/test_pftools.py
@@ -54,13 +54,13 @@ __all__ = ["PFToolsTestCase"]
 class PFToolsTestCase(unittest.TestCase):
     def test_reaction_analysis_sterck(self):
         pf_react1 = PartFun(NMA(load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/aa.fchk"))),
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/aa.fchk"))),
             [ExtTrans(cp=False), ExtRot(1)])
         pf_react2 = PartFun(NMA(load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/aarad.fchk"))),
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/aarad.fchk"))),
             [ExtTrans(cp=False), ExtRot(1)])
         pf_ts = PartFun(NMA(load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/sterck/paats.fchk"))),
+            pkg_resources.resource_filename("tamkin", "data/test/sterck/paats.fchk"))),
             [ExtTrans(cp=False), ExtRot(1)])
 
         km = KineticModel([pf_react1, pf_react2], pf_ts)
@@ -80,9 +80,9 @@ class PFToolsTestCase(unittest.TestCase):
 
     def test_reaction_analysis_mat(self):
         pf_react = PartFun(NMA(load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/mat5T/react.fchk"))), [])
+            pkg_resources.resource_filename("tamkin", "data/test/mat5T/react.fchk"))), [])
         pf_ts = PartFun(NMA(load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/mat5T/ts.fchk"))), [])
+            pkg_resources.resource_filename("tamkin", "data/test/mat5T/ts.fchk"))), [])
 
         km = KineticModel([pf_react], pf_ts)
         ra = ReactionAnalysis(km, 100, 1200, temp_step=50)
@@ -123,7 +123,7 @@ class PFToolsTestCase(unittest.TestCase):
     def test_thermo_analysis_mat(self):
         # just a blind test to see test whether the code does not crash.
         pf = PartFun(NMA(load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/mat5T/react.fchk"))),
+            pkg_resources.resource_filename("tamkin", "data/test/mat5T/react.fchk"))),
             [ExtTrans(), ExtRot(1)])
         ta = ThermoAnalysis(pf, [200,300,400,500,600,700,800,900])
         with tmpdir(__name__, 'test_thermo_analysis_mat') as dn:

--- a/tamkin/test/test_rotor.py
+++ b/tamkin/test/test_rotor.py
@@ -54,12 +54,12 @@ __all__ = ["RotorTestCase"]
 
 class RotorTestCase(unittest.TestCase):
     def assertArraysAlmostEqual(self, a, b, eps=1e-5, relative=False):
-        self.assert_(isinstance(b, np.ndarray))
+        assert isinstance(b, np.ndarray)
         self.assertEqual(a.shape, b.shape)
         if relative:
-            self.assert_(abs(2*(a-b)/(a+b)).max() <= eps)
+            assert abs(2*(a-b)/(a+b)).max() <= eps
         else:
-            self.assert_(abs(a-b).max() <= eps)
+            assert abs(a-b).max() <= eps
 
     def test_potential_op(self):
         a = 10.0
@@ -179,7 +179,7 @@ class RotorTestCase(unittest.TestCase):
         for i0 in range(nmax):
             for i1 in range(nmax):
                 check = np.dot(lc_dagger, np.dot(v_op_exp[2*i0+1:2*i0+3,2*i1+1:2*i1+3], lc))
-                self.assert_(abs(check.imag).max() < 1e-3)
+                assert abs(check.imag).max() < 1e-3
                 check = check.real
                 self.assertArraysAlmostEqual(
                     v_op_cs[2*i0+1:2*i0+3,2*i1+1:2*i1+3],
@@ -208,10 +208,10 @@ class RotorTestCase(unittest.TestCase):
 
     def test_flat2(self):
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/ethane/gaussian.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/ethane/gaussian.fchk"))
         nma = NMA(molecule)
         rotscan1 = load_rotscan_g03log(
-            pkg_resources.resource_filename(__name__, "../data/test/rotor/gaussian.log"))
+            pkg_resources.resource_filename("tamkin", "data/test/rotor/gaussian.log"))
         my_potential = rotscan1.potential.copy()
         my_potential[1][:] = nma.energy
         rotscan1 = rotscan1.copy_with(potential=my_potential)
@@ -259,10 +259,10 @@ class RotorTestCase(unittest.TestCase):
 
     def test_ethane_hindered(self):
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/ethane/gaussian.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/ethane/gaussian.fchk"))
         nma = NMA(molecule)
         rot_scan = load_rotscan_g03log(
-            pkg_resources.resource_filename(__name__, "../data/test/rotor/gaussian.log"))
+            pkg_resources.resource_filename("tamkin", "data/test/rotor/gaussian.log"))
         rotor = Rotor(rot_scan, molecule, rotsym=3, even=True, cancel_freq='scan')
         pf = PartFun(nma, [ExtTrans(), ExtRot(6), rotor])
         self.assertAlmostEqual(rotor.cancel_freq/lightspeed*centimeter, 298, 0)
@@ -291,7 +291,7 @@ class RotorTestCase(unittest.TestCase):
 
     def test_ethyl_free(self):
         molecule = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/ethyl/gaussian.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/ethyl/gaussian.fchk"))
         nma = NMA(molecule)
         dihedral = [5, 1, 0, 2]
         rot_scan = RotScan(dihedral, molecule)
@@ -342,7 +342,7 @@ class RotorTestCase(unittest.TestCase):
         for fn_xyz, i0, i1, top, expected in cases:
             # preparation
             mol = XYZFile(pkg_resources.resource_filename(
-                __name__, os.path.join("../data/test/imom", fn_xyz))).get_molecule()
+                "tamkin", os.path.join("data/test/imom", fn_xyz))).get_molecule()
             masses = np.array([periodic[n].mass for n in mol.numbers])
             masses3 = np.array([masses, masses, masses]).transpose().ravel()
             center = mol.coordinates[i0]
@@ -396,6 +396,6 @@ class RotorTestCase(unittest.TestCase):
 
     def test_load_rotor_margot(self):
         rot_scan = load_rotscan_g03log(
-            pkg_resources.resource_filename(__name__, "../data/test/rotor/margot.log"))
+            pkg_resources.resource_filename("tamkin", "data/test/rotor/margot.log"))
         assert rot_scan.potential.shape == (2, 1)
         assert (rot_scan.dihedral == [2, 3, 4, 5]).all()

--- a/tamkin/test/test_tunneling.py
+++ b/tamkin/test/test_tunneling.py
@@ -112,11 +112,11 @@ class TunnelingTestCase(unittest.TestCase):
 
     def test_eckart_init(self):
         fixed_atoms = load_fixed_g03com(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.14mei.com"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.14mei.com"))
         mol_react = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_react.28aug.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_react.28aug.fchk"))
         mol_trans = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/mat/Zp_p_TS.28aug.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/mat/Zp_p_TS.28aug.fchk"))
 
         pf_react = PartFun(NMA(mol_react, PHVA(fixed_atoms)))
         pf_trans = PartFun(NMA(mol_trans, PHVA(fixed_atoms)))
@@ -125,13 +125,13 @@ class TunnelingTestCase(unittest.TestCase):
 
     def test_eckart_tugba(self):
         mol_react1 = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/tugba/monomer.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/tugba/monomer.fchk"))
         mol_react2 = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/tugba/radical.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/tugba/radical.fchk"))
         mol_trans = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/tugba/ts.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/tugba/ts.fchk"))
         mol_prod = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/tugba/prod.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/tugba/prod.fchk"))
 
         pf_react1 = PartFun(NMA(mol_react1))
         pf_react2 = PartFun(NMA(mol_react2))
@@ -143,7 +143,7 @@ class TunnelingTestCase(unittest.TestCase):
 
     def test_miller_tugba(self):
         mol_trans = load_molecule_g03fchk(
-            pkg_resources.resource_filename(__name__, "../data/test/tugba/ts.fchk"))
+            pkg_resources.resource_filename("tamkin", "data/test/tugba/ts.fchk"))
         pf_trans = PartFun(NMA(mol_trans))
         miller = Miller(pf_trans)
         miller(np.array([620,770]))


### PR DESCRIPTION
This will no longer be supported in future versions of pkg_resources. This fixes addresses the warnings when running the tests with pytest.